### PR TITLE
Update to support V11 and current ARS release

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
   "socket": true,
   "url": "https://github.com/drplote/fvtt-hackmaster-4e",
   "readme": "https://github.com/drplote/fvtt-hackmaster-4e/raw/main/README.md",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "esmodules": [
     "scripts/hackmaster4e.js"
   ],
@@ -24,7 +24,7 @@
   "relationships": {
     "systems": [
       {
-        "id": "osric",
+        "id": "ars",
         "type": "system",
         "compatibility": {}
       }
@@ -38,7 +38,7 @@
     ]
   },
   "compatibility": {
-    "minimum": "10",
-    "verified": "10"
+    "minimum": "11",
+    "verified": "11"
   }
 }

--- a/scripts/Modules/armor-info.js
+++ b/scripts/Modules/armor-info.js
@@ -6,11 +6,11 @@ export class ArmorInfo{
 	}
 
     getFlag(flag){
-        return this._itemData.getFlag("osric", flag);
+        return this._itemData.getFlag("ars", flag);
     }
 
     setFlag(flag, value){
-        return this._itemData.setFlag("osric", flag, value);
+        return this._itemData.setFlag("ars", flag, value);
     }
 
     toggleFlag(flag){
@@ -101,7 +101,7 @@ export class ArmorInfo{
     }
 
     get isEquipped(){
-        const locationState = game.osric.library.const.location;
+        const locationState = game.ars.library.const.location;
         return this._itemData?.system?.location?.state == locationState.EQUIPPED;
     }
 

--- a/scripts/Modules/hackmaster-actor.js
+++ b/scripts/Modules/hackmaster-actor.js
@@ -4,12 +4,12 @@ import { HonorCalculator } from "./honor-calculator.js";
 
 export class HackmasterActor {
 
-    constructor(osricActor) {
-        this._osricActor = osricActor;
+    constructor(ARSActor) {
+        this._ARSActor = ARSActor;
     }
 
     getItems(){
-        let items = this._osricActor?.items ?? [];
+        let items = this._ARSActor?.items ?? [];
         return items.map(i => new HackmasterItem(i));
     }
 
@@ -26,24 +26,24 @@ export class HackmasterActor {
     }
 
     get isProtegee(){
-        return this._osricActor?.system?.isProtegee ?? false;
+        return this._ARSActor?.system?.isProtegee ?? false;
     }
 
     get temporaryHonor(){
-        return this._osricActor?.system?.honor?.temp ?? 0;
+        return this._ARSActor?.system?.honor?.temp ?? 0;
     }
 
     get honor() {
-        return this._osricActor?.system?.honor?.value ?? 0;
+        return this._ARSActor?.system?.honor?.value ?? 0;
     }
 
     
     get comeliness(){
-        return this._osricActor?.system?.comeliness?.value ?? 10;
+        return this._ARSActor?.system?.comeliness?.value ?? 10;
     }
 
     get comelinessPercent(){
-        return this._osricActor?.system?.comeliness?.percent ?? 0;
+        return this._ARSActor?.system?.comeliness?.percent ?? 0;
     }
 
     get comelinessDescription(){
@@ -52,19 +52,19 @@ export class HackmasterActor {
     }
 
     get effectiveLevel() {
-        return this._osricActor?.effectiveLevel ?? 0;
+        return this._ARSActor?.effectiveLevel ?? 0;
     }
 
     get isNpc() {
-        return this._osricActor?.type == 'npc';
+        return this._ARSActor?.type == 'npc';
     }
 
     get thac0(){
-        return this._osricActor?.system?.attributes?.thaco?.value ?? 20;
+        return this._ARSActor?.system?.attributes?.thaco?.value ?? 20;
     }
 
     get armorClass(){
-        return this._osricActor?.system?.armorClass ?? [];
+        return this._ARSActor?.system?.armorClass ?? [];
     }
 
     getArmorClass(type){
@@ -77,7 +77,7 @@ export class HackmasterActor {
 
    
     get size(){
-        return this._osricActor?.system?.attributes?.size ?? 'medium';
+        return this._ARSActor?.system?.attributes?.size ?? 'medium';
     }
 
     get sizeCategory(){
@@ -102,7 +102,7 @@ export class HackmasterActor {
     }
 
     get rawHonorState(){
-        return this._osricActor?.system?.honorState ?? 0
+        return this._ARSActor?.system?.honorState ?? 0
     }
 
     getHonorState() {
@@ -133,15 +133,15 @@ export class HackmasterActor {
     }
 
     get thresholdOfPain(){
-        return Math.floor((this._osricActor?.system?.attributes?.hp?.max ?? 0) / 2);
+        return Math.floor((this._ARSActor?.system?.attributes?.hp?.max ?? 0) / 2);
     }
 
     get recentDamageTaken(){
-        return this._osricActor?.system?.recentDamage ?? 0;
+        return this._ARSActor?.system?.recentDamage ?? 0;
     }
 
     async setRecentDamageTaken(amount){
-        if (this._osricActor){
+        if (this._ARSActor){
             await Utilities.runAsGM({
                 operation: 'updateActor',
                 targetActorId: this.isNpc ? null : this.actorId,
@@ -154,7 +154,7 @@ export class HackmasterActor {
     }
 
     get isDead(){
-        return this._osricActor?.isDead ?? false;
+        return this._ARSActor?.isDead ?? false;
     }
 
     async recordDamageTaken(amount){
@@ -170,14 +170,14 @@ export class HackmasterActor {
     }
 
     get name() {
-        return this._osricActor?.getName() ?? '';
+        return this._ARSActor?.getName() ?? '';
     }
 
     get actorId(){
-        return this._osricActor?.id;
+        return this._ARSActor?.id;
     }
 
     get tokenId(){
-        return this._osricActor?.token?.id;
+        return this._ARSActor?.token?.id;
     }
 }

--- a/scripts/Modules/hackmaster-item.js
+++ b/scripts/Modules/hackmaster-item.js
@@ -2,12 +2,12 @@ import { ArmorInfo } from "./armor-info.js";
 
 export class HackmasterItem{
 
-    constructor(osricItem){
-        this._osricItem = osricItem;
+    constructor(ARSItem){
+        this._ARSItem = ARSItem;
     }
 
     get type(){
-        return this._osricItem?.type;
+        return this._ARSItem?.type;
     }
 
     get isArmor(){
@@ -15,7 +15,7 @@ export class HackmasterItem{
     }
 
     get protectionType(){
-        return this._osricItem?.system?.protection?.type;
+        return this._ARSItem?.system?.protection?.type;
     }
 
     get isShield(){
@@ -23,22 +23,22 @@ export class HackmasterItem{
     }
 
     get isEquipped(){
-        return this._osricItem?.system?.location?.state == game.osric.library.const.location.EQUIPPED;        
+        return this._ARSItem?.system?.location?.state == game.ars.library.const.location.EQUIPPED;        
     }
 
     get isMagic() {
-        return this._osricItem?.isMagic ?? false;
+        return this._ARSItem?.isMagic ?? false;
     }
 
     getArmorInfo(){
         if (this.isArmor || this.isShield){
-            return new ArmorInfo(this._osricItem);
+            return new ArmorInfo(this._ARSItem);
         }
         return null;
     }
 
     get rawDamageData(){
-        return this._osricItem?.system?.damage ?? {};
+        return this._ARSItem?.system?.damage ?? {};
     }
 
     getDamageForSizeCategory(sizeCategory){

--- a/scripts/Overrides/actor-overrides.js
+++ b/scripts/Overrides/actor-overrides.js
@@ -1,7 +1,7 @@
 import { libWrapper } from '../shim.js';
 import { Hackmaster } from '../config.js';
 
-export class OsricActorOverrides {
+export class ARSActorOverrides {
 
 	static initialize(){
 		this.overrideStatBonuses();
@@ -46,7 +46,7 @@ export class OsricActorOverrides {
   
 		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'CONFIG.Actor.documentClass.prototype._buildAbilityFields', (function() {
 			return function(data) {
-				OsricActorOverrides._buildAbilityFields(data);
+				ARSActorOverrides._buildAbilityFields(data);
 			};
 		})(), 'OVERRIDE');
 	}

--- a/scripts/Overrides/combat-overrides.js
+++ b/scripts/Overrides/combat-overrides.js
@@ -1,17 +1,18 @@
 import { HackmasterCombatManager } from '../Modules/hackmaster-combat-manager.js';
 import { libWrapper } from '../shim.js';
+//import * from '../dice/dice.js'
 
-export class OsricCombatOverrides {
+export class ARSCombatOverrides {
     static initialize(){
-        OsricCombatOverrides.overrideDamageRoll();
-		OsricCombatOverrides.overrideAttackRoll();
-		OsricCombatOverrides.overrideApplyDamageAdjustments();
-		OsricCombatOverrides.overrideSendHealthAdjustChatCard();
-		OsricCombatOverrides.overrideGetDamageFormulas();
+        ARSCombatOverrides.overrideDamageRoll();
+		ARSCombatOverrides.overrideAttackRoll();
+		ARSCombatOverrides.overrideApplyDamageAdjustments();
+		ARSCombatOverrides.overrideSendHealthAdjustChatCard();
+		ARSCombatOverrides.overrideGetDamageFormulas();
 	}
 
 	static overrideGetDamageFormulas(){
-		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.osric.diceManager.adjustHPRoll', async function(wrapped, ...args) {
+		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.ars.diceManager.adjustHPRoll', async function(wrapped, ...args) {
 			let dd = args[0];
 			let targetToken = args.length > 1 ? args[1] : null;
 			HackmasterCombatManager.replaceDamageForCorrectSize(dd, targetToken);
@@ -20,7 +21,7 @@ export class OsricCombatOverrides {
 	}
 
 	static overrideSendHealthAdjustChatCard(){
-		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.osric.combatManager.sendHealthAdjustChatCard', async function(wrapped, ...args) {
+		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.ars.combatManager.sendHealthAdjustChatCard', async function(wrapped, ...args) {
 			await wrapped(...args);
 
 			let targetToken = args[1];
@@ -38,7 +39,7 @@ export class OsricCombatOverrides {
 			HackmasterCombatManager.applyHonorToAttackRoll(dd, bonusFormula, additionalRollData);
 		});
 
-		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.osric.diceManager.osricAttackRoll', async function(wrapped, ...args) {
+		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.ars.diceManager.systemAttackRoll', async function(wrapped, ...args) {
 			let roll = await wrapped(...args);
 			let dd = args[0];
 			let targetToken = args[1];
@@ -50,14 +51,14 @@ export class OsricCombatOverrides {
 	}
 
     static overrideDamageRoll(){
-		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.osric.combatManager.getRolledDamage', async function(wrapped, ...args) {
+		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.ars.combatManager.getRolledDamage', async function(wrapped, ...args) {
 			await wrapped(...args);
 			HackmasterCombatManager.applyHonorToDamageRoll(args[0]);			
 		}, 'WRAPPER');
 	}
 
 	static overrideApplyDamageAdjustments(){
-		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.osric.combatManager.applyDamageAdjustments', async function(wrapped, ...args) {
+		libWrapper.register(CONFIG.Hackmaster.MODULE_ID, 'game.ars.combatManager.applyDamageAdjustments', async function(wrapped, ...args) {
 			let result = await wrapped(...args);
 			return await HackmasterCombatManager.applyArmorSoak(result, ...args);			
 		}, 'WRAPPER');

--- a/scripts/Overrides/combat-tracker-overrides.js
+++ b/scripts/Overrides/combat-tracker-overrides.js
@@ -2,11 +2,11 @@ import { HackmasterActor } from '../Modules/hackmaster-actor.js';
 import { HackmasterCombatManager } from '../Modules/hackmaster-combat-manager.js';
 import { HackmasterSettings } from '../Modules/hackmaster-settings.js';
 
-export class OsricCombatTrackerOverrides {
+export class ARSCombatTrackerOverrides {
 	static initialize(){
-		OsricCombatTrackerOverrides.overrideUpdateCombat();
-    OsricCombatTrackerOverrides.overrideProcessOngoingHealthAdjustments();
-    OsricCombatTrackerOverrides.overrideCombatRollInitiative();
+		ARSCombatTrackerOverrides.overrideUpdateCombat();
+    		ARSCombatTrackerOverrides.overrideProcessOngoingHealthAdjustments();
+    		ARSCombatTrackerOverrides.overrideCombatRollInitiative();
 	}
 
   static overrideCombatRollInitiative(){

--- a/scripts/hackmaster-character-sheet.js
+++ b/scripts/hackmaster-character-sheet.js
@@ -30,7 +30,7 @@ export class HackmasterCharacterSheet {
 	}
 
 	getArmors(){
-		let armors = this.inventory.filter(i => 
+		let armors = this._sheet.object.inventory.filter(i => 
 			i.type === "armor" && 
 			(i.system.protection.type === "armor" || i.system.protection.type === "shield")
 		).map(a => new ArmorInfo(a));
@@ -124,7 +124,7 @@ export class HackmasterCharacterSheet {
 	}
 
 	async insertArmorTrackers(){
-		let combatBox = this.findElement(".combat-stats");
+		let combatBox = this.findElement(".ability-save-grid");
 		let section = await this.buildArmorDamageSection();
 		combatBox.append(section);
 		await Promise.all(this.getArmors().map(a => this.insertArmorTracker(a)));

--- a/scripts/hackmaster4e.js
+++ b/scripts/hackmaster4e.js
@@ -1,10 +1,10 @@
-import { OsricActorOverrides } from './Overrides/actor-overrides.js';
+import { ARSActorOverrides } from './Overrides/actor-overrides.js';
 import { HackmasterCharacterSheet } from "./hackmaster-character-sheet.js";
 import { HackmasterItemSheet } from './hackmaster-item-sheet.js';
 import { Hackmaster } from './config.js';
 import { AlwaysHpSupport } from './always-hp-support.js';
-import { OsricCombatTrackerOverrides } from './Overrides/combat-tracker-overrides.js';
-import { OsricCombatOverrides } from './Overrides/combat-overrides.js';
+import { ARSCombatTrackerOverrides } from './Overrides/combat-tracker-overrides.js';
+import { ARSCombatOverrides } from './Overrides/combat-overrides.js';
 import { HackmasterChatCommands } from './Modules/hackmaster-chat-commands.js';
 import { Utilities } from './utilities.js';
 import { HackmasterSettings } from './Modules/hackmaster-settings.js';
@@ -38,7 +38,7 @@ function listenForGmCommands(){
   });
 }
 
-function updateOsricConfig(){
+function updateARSConfig(){
   CONFIG.ARS.icons.general.actors['npc'] = 'icons/svg/mystery-man-black.svg';
 }
 
@@ -54,12 +54,12 @@ Hooks.once('init', function() {
 
   CONFIG.Hackmaster = Hackmaster;
 
-  updateOsricConfig();
-  OsricActorOverrides.initialize();
+  updateARSConfig();
+  ARSActorOverrides.initialize();
   HackmasterCharacterSheet.initialize();
-  OsricCombatTrackerOverrides.initialize();
+  ARSCombatTrackerOverrides.initialize();
   AlwaysHpSupport.initialize();
-  OsricCombatOverrides.initialize();
+  ARSCombatOverrides.initialize();
   HackmasterChatCommands.initialize();
   HackmasterItemSheet.initialize();
   HackmasterSettings.initialize();
@@ -72,10 +72,10 @@ Hooks.once('init', function() {
 
 //   // Define the config for our package
 //   const config = {
-//       packageName: "osric",
+//       packageName: "ARS",
 //       sheetClasses: [
 //           {
-//               name: "OSRICItemSheet", // this _must_ be the class name of the `Application` you want it to apply to
+//               name: "ARSItemSheet", // this _must_ be the class name of the `Application` you want it to apply to
 //               fieldConfigs: [
 //                   {
 //                       selector: `input[type="text"]`, // this targets all text input fields on the "details" tab. Any css selector should work here.
@@ -87,7 +87,7 @@ Hooks.once('init', function() {
 //               ]
 //           },
 //           {
-//             name: "OSRICCharacterSheet", // this _must_ be the class name of the `Application` you want it to apply to
+//             name: "ARSCharacterSheet", // this _must_ be the class name of the `Application` you want it to apply to
 //             fieldConfigs: [
 //                 {
 //                     selector: `input[type="text"]`, // this targets all text input fields on the "details" tab. Any css selector should work here.
@@ -99,7 +99,7 @@ Hooks.once('init', function() {
 //             ]
 //           },
 //           {
-//             name: "OSRICNPCSheet", // this _must_ be the class name of the `Application` you want it to apply to
+//             name: "ARSNPCSheet", // this _must_ be the class name of the `Application` you want it to apply to
 //             fieldConfigs: [
 //                 {
 //                     selector: `input[type="text"]`, // this targets all text input fields on the "details" tab. Any css selector should work here.

--- a/scripts/utilities.js
+++ b/scripts/utilities.js
@@ -38,7 +38,7 @@ export class Utilities {
             content: content,
             user: game.user.id,
             speaker: sourceSpeaker,
-            type: type ?? game.osric.const.CHAT_MESSAGE_TYPES.OTHER,
+            type: type ?? game.ars.const.CHAT_MESSAGE_TYPES.OTHER,
         };
         ChatMessage.create(chatData);
     }
@@ -137,11 +137,11 @@ export class Utilities {
         } else
             // check to see if the GM we found is the person we've emit'd to and if so run command.
             if (findGM.id === game.user.id) {
-                if (!game.osric.runAsGMRequestIds[data.requestId]) {
+                if (!game.ars.runAsGMRequestIds[data.requestId]) {
    
                     // We do this to make sure the command is only run once if more than 
                     // one GM is on the server
-                    game.osric.runAsGMRequestIds[data.requestId] = data.requestId;
+                    game.ars.runAsGMRequestIds[data.requestId] = data.requestId;
     
                     /**
                      * "data" is serialized and deserialized so the type is lost.


### PR DESCRIPTION
Changes added to support Foundry V11 and support for the current ARS release. Version updated to 1.3.5.

Armor tracker is currently on the the character main page with stats instead of the combat page. This can be changed later but appears to be the cleanest approach presently.

Need to follow up on change in hackmaster-character-sheet.js under getArmors(). It is currently working but the change may be unnecessary or bad practice. 

.inventory was changed to ._sheet.object.inventory. 

IS: let armors = this._sheet.object.inventory.filter(i => 
WAS: let armors = this.inventory.filter(i => 
